### PR TITLE
Security settings for solr_wrapper, data persistence

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -5,3 +5,7 @@ download_dir: tmp/solr
 collection:
   dir: solr/conf/
   name: blacklight-core
+  persist: true
+env:
+  # Only allow Jetty to use the local adapter
+  SOLR_OPTS: "-Djetty.host=127.0.0.1 -Dlog4j2.formatMsgNoLookups=True"


### PR DESCRIPTION
* Restrict Solr to start only on 127.0.0.1 from solr_wrapper (default uses all interfaces 0.0.0.0)
* Apply extra config to mitigate log4j issues
* Persist dev solr data by default