### PR TITLE
Bug fix: resolve missing catalog_facet_url route

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   NewCops: enable
   Exclude:
   - '.internal_test_app/**/*'
+  - 'app/controllers/concerns/spotlight/controller.rb'
   - 'bin/**/*'
   - 'db/**/*'
   - 'Gemfile'
@@ -26,7 +27,9 @@ Layout/LineLength:
 
 Metrics/BlockLength:
   Exclude:
+  - 'app/controllers/catalog_controller.rb'
   - 'lib/tasks/umedia.rake'
+
 
 Minitest/MultipleAssertions:
   Max: 20

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,6 +36,40 @@ class CatalogController < ApplicationController
 
     # enable facets:
     # https://github.com/projectblacklight/spotlight/issues/1812#issuecomment-327345318
+
+  # FACETS
+    # Special Projects / super_collection_name_ss
+
+    # Contributing Organization / contributing_organization_name_s
+    config.add_facet_field 'contributing_organization_ssi', :label => 'Contributing Organization', :limit => 8, collapse: false
+
+    # Collection / collection_name_s
+    config.add_facet_field 'collection_name_ssi', :label => 'Collection', :limit => 8, collapse: false
+
+    # Type / types
+    config.add_facet_field 'type_ssi', :label => 'Type', :limit => 8, collapse: false
+
+    # Format / format_name
+    config.add_facet_field 'format_name_ssimv', :label => 'Format', :limit => 8, collapse: false
+
+    # Created / date_created_ss
+    config.add_facet_field 'date_created_sort_ssortsi', :label => 'Created', :limit => 8, collapse: false
+
+    # Subject / subject_ss
+    config.add_facet_field 'subject_ssim', :label => 'Subject', :limit => 8, collapse: false
+
+    # Creator / creator_ss
+    config.add_facet_field 'creator_ssim', :label => 'Creator', :limit => 8, collapse: false
+
+    # Publisher / publisher_s
+    config.add_facet_field 'publisher_ssi', :label => 'Publisher', :limit => 8, collapse: false
+
+    # Contributor / contributor_ss
+    config.add_facet_field 'contributor_ssim', :label => 'Contributor', :limit => 8, collapse: false
+
+    # Language / language
+    config.add_facet_field 'language_ssi', :label => 'Language', :limit => 8, collapse: false
+
     config.add_facet_fields_to_solr_request!
 
     # Set which views by default only have the title displayed, e.g.,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -37,38 +37,39 @@ class CatalogController < ApplicationController
     # enable facets:
     # https://github.com/projectblacklight/spotlight/issues/1812#issuecomment-327345318
 
-  # FACETS
+    # FACETS
     # Special Projects / super_collection_name_ss
 
     # Contributing Organization / contributing_organization_name_s
-    config.add_facet_field 'contributing_organization_ssi', :label => 'Contributing Organization', :limit => 8, collapse: false
+    config.add_facet_field 'contributing_organization_ssi', label: 'Contributing Organization', limit: 8,
+                                                            collapse: false
 
     # Collection / collection_name_s
-    config.add_facet_field 'collection_name_ssi', :label => 'Collection', :limit => 8, collapse: false
+    config.add_facet_field 'collection_name_ssi', label: 'Collection', limit: 8, collapse: false
 
     # Type / types
-    config.add_facet_field 'type_ssi', :label => 'Type', :limit => 8, collapse: false
+    config.add_facet_field 'type_ssi', label: 'Type', limit: 8, collapse: false
 
     # Format / format_name
-    config.add_facet_field 'format_name_ssimv', :label => 'Format', :limit => 8, collapse: false
+    config.add_facet_field 'format_name_ssimv', label: 'Format', limit: 8, collapse: false
 
     # Created / date_created_ss
-    config.add_facet_field 'date_created_sort_ssortsi', :label => 'Created', :limit => 8, collapse: false
+    config.add_facet_field 'date_created_sort_ssortsi', label: 'Created', limit: 8, collapse: false
 
     # Subject / subject_ss
-    config.add_facet_field 'subject_ssim', :label => 'Subject', :limit => 8, collapse: false
+    config.add_facet_field 'subject_ssim', label: 'Subject', limit: 8, collapse: false
 
     # Creator / creator_ss
-    config.add_facet_field 'creator_ssim', :label => 'Creator', :limit => 8, collapse: false
+    config.add_facet_field 'creator_ssim', label: 'Creator', limit: 8, collapse: false
 
     # Publisher / publisher_s
-    config.add_facet_field 'publisher_ssi', :label => 'Publisher', :limit => 8, collapse: false
+    config.add_facet_field 'publisher_ssi', label: 'Publisher', limit: 8, collapse: false
 
     # Contributor / contributor_ss
-    config.add_facet_field 'contributor_ssim', :label => 'Contributor', :limit => 8, collapse: false
+    config.add_facet_field 'contributor_ssim', label: 'Contributor', limit: 8, collapse: false
 
     # Language / language
-    config.add_facet_field 'language_ssi', :label => 'Language', :limit => 8, collapse: false
+    config.add_facet_field 'language_ssi', label: 'Language', limit: 8, collapse: false
 
     config.add_facet_fields_to_solr_request!
 

--- a/app/controllers/concerns/spotlight/controller.rb
+++ b/app/controllers/concerns/spotlight/controller.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Spotlight controller helpers
+  module Controller
+    extend ActiveSupport::Concern
+    include Blacklight::Controller
+    include Spotlight::Config
+
+    included do
+      helper_method :current_site, :current_exhibit, :current_masthead, :exhibit_masthead?, :resource_masthead?
+      before_action :set_exhibit_locale_scope, :set_locale
+    end
+
+    def set_exhibit_locale_scope
+      Translation.current_exhibit = current_exhibit
+    end
+
+    def current_site
+      @current_site ||= Spotlight::Site.instance
+    end
+
+    def current_exhibit
+      @exhibit || (Spotlight::Exhibit.find(params[:exhibit_id]) if params[:exhibit_id].present?)
+    end
+
+    def current_masthead
+      @masthead ||= if resource_masthead?
+                      # TODO: is there a way to get this generically, instead of requiring controllers
+                      #  to override #current_masthead or set it explicitly?. In the meantime, `nil` is
+                      #  hopefully less confusing than a wrong value.
+                      nil
+                    elsif current_exhibit
+                      current_exhibit.masthead if exhibit_masthead?
+                    elsif current_site.masthead&.display?
+                      current_site.masthead
+                    end
+    end
+
+    def current_masthead=(masthead)
+      @masthead = masthead
+    end
+
+    def resource_masthead?
+      false
+    end
+
+    def exhibit_masthead?
+      current_exhibit&.masthead && current_exhibit.masthead.display?
+    end
+
+    def set_locale
+      I18n.locale = params[:locale] || I18n.default_locale
+    end
+
+    def default_url_options
+      super.merge(locale: (I18n.locale if I18n.locale != I18n.default_locale))
+    end
+
+    # overwrites Blacklight::Controller#blacklight_config
+    def blacklight_config
+      if current_exhibit
+        exhibit_specific_blacklight_config
+      else
+        default_catalog_controller.blacklight_config
+      end
+    end
+
+    def search_action_url(*args, **kwargs)
+      if current_exhibit
+        exhibit_search_action_url(*args, **kwargs)
+      else
+        main_app.search_catalog_url(*args, **kwargs)
+      end
+    end
+
+    def search_facet_path(*args, **kwargs)
+      if current_exhibit
+        exhibit_search_facet_path(*args, **kwargs)
+      else
+        # Bug in Spotlight?
+        # This Route Helper does not exist...
+        #   main_app.catalog_facet_url(*args, **kwargs)
+        # We can use this one instead...
+        main_app.facet_catalog_url(*args, **kwargs)
+      end
+    end
+
+    def exhibit_search_action_url(*args, **kwargs)
+      options = args.extract_options!
+      options = options.merge(kwargs)
+      only_path = options[:only_path]
+      options.except! :exhibit_id, :only_path
+
+      if only_path
+        spotlight.search_exhibit_catalog_path(current_exhibit, *args, **options)
+      else
+        spotlight.search_exhibit_catalog_url(current_exhibit, *args, **options)
+      end
+    end
+
+    def exhibit_search_facet_path(*args, **kwargs)
+      options = args.extract_options!
+      options = Blacklight::Parameters.sanitize(params.to_unsafe_h.with_indifferent_access).merge(options).merge(kwargs).except(:exhibit_id, :only_path)
+      spotlight.facet_exhibit_catalog_url(current_exhibit, *args, **options&.symbolize_keys)
+    end
+  end
+end


### PR DESCRIPTION
Spotlight appears to have a bug that prevents some facets displaying by default. This corrects the issue by:
1) Adds many facets to catalog_controller.rb
2) Overwrites Spotlight's default controller.rb concern to map the `catalog_facet_url` (errors) call to `facet_catalog_url` instead.
3) Opened issue upstream in Spotlight: https://github.com/projectblacklight/spotlight/issues/2810

Fixes #11