### PR TITLE
Add basic robots.txt controller

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,5 @@
+class RobotsController < ApplicationController
+  def robots
+    respond_to :text
+  end
+end

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Basic robots.txt generator
 class RobotsController < ApplicationController
   def robots
     respond_to :text

--- a/app/views/robots/robots.text.erb
+++ b/app/views/robots/robots.text.erb
@@ -1,0 +1,27 @@
+<%- if File.exists? "#{Rails.root}/public/sitemap.xml.gz" -%>
+Sitemap: <%= "#{root_url}sitemap.xml.gz" %>
+<%- end -%>
+
+<%- if Socket.gethostname =~ /(dev|qat|stage)/ -%>
+User-agent: *
+Disallow: /
+<%- else -%>
+
+User-agent: *
+Disallow: /?q=
+Disallow: /?f
+Disallow: /?_
+Disallow: /catalog?f
+Disallow: /catalog?_
+Disallow: /catalog.html?f
+Disallow: /catalog.html?_
+Disallow: /catalog.atom
+Disallow: /catalog.rss
+
+User-agent: AhrefsBot
+Disallow: /
+User-agent: SemrushBot
+Disallow: /
+User-agent: PetalBot
+Disallow: /
+<%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,5 +29,7 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  get 'robots.:format' => 'robots#robots'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,0 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file

--- a/test/controllers/robots_controller_test.rb
+++ b/test/controllers/robots_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class RobotsControllerTest < ActionDispatch::IntegrationTest
+  test "should return a robots file" do
+    get '/robots.txt'
+    assert_response :success
+  end
+end
+

--- a/test/controllers/robots_controller_test.rb
+++ b/test/controllers/robots_controller_test.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
+# Validate robots.txt generation
 class RobotsControllerTest < ActionDispatch::IntegrationTest
-  test "should return a robots file" do
+  test 'should return a robots file' do
     get '/robots.txt'
     assert_response :success
   end
 end
-


### PR DESCRIPTION
Fixes #5 

- `robots.txt` is generated dynamically, detecting the the presence of public/sitemap.xml.gz.
- Hosts matching `dev, qat, stage` by a server side hostname lookup get universal Disallow for all crawling.
- Hosts not matching those patterns get specific rules to discourage known bad behaving robots and all others from attempting to crawl facets.