### PR TITLE
CatalogController: field configuration, system testing

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,52 +26,120 @@ class CatalogController < ApplicationController
     config.document_unique_id_param = 'ids'
 
     # solr field configuration for search results/index views
-    config.index.title_field = 'full_title_tesim'
+    config.index.title_field = 'title_ssi'
 
     config.add_search_field 'all_fields', label: I18n.t('spotlight.search.fields.search.all_fields')
 
     config.add_sort_field 'relevance', sort: 'score desc', label: I18n.t('spotlight.search.fields.sort.relevance')
-
-    config.add_field_configuration_to_solr_request!
-
-    # enable facets:
-    # https://github.com/projectblacklight/spotlight/issues/1812#issuecomment-327345318
+    config.add_sort_field "date_created_sort_ssortsi desc, title_sort_ssortsi asc", :label => 'Year (Newest first)'
+    config.add_sort_field "date_created_sort_ssortsi asc, title_sort_ssortsi asc", :label => 'Year (Oldest first)'
+    config.add_sort_field 'title_sort_ssortsi asc', :label => 'Title (A-Z)'
+    config.add_sort_field 'title_sort_ssortsi desc', :label => 'Title (Z-A)'
+    config.add_sort_field 'creator_sort_ssortsi asc', :label => 'Creator (A-Z)'
+    config.add_sort_field 'creator_sort_ssortsi desc', :label => 'Creator (Z-A)'
 
     # FACETS
-    # Special Projects / super_collection_name_ss
+    # Contributing Organization / contributing_organization_ssi
+    config.add_facet_field 'contributing_organization_ssi', label: 'Contributing Organization',
+                           limit: 4, collapse: true
 
-    # Contributing Organization / contributing_organization_name_s
-    config.add_facet_field 'contributing_organization_ssi', label: 'Contributing Organization', limit: 8,
-                                                            collapse: false
+    # Collection / collection_name_ssi
+    config.add_facet_field 'collection_name_ssi', label: 'Collection', limit: 4, collapse: true
 
-    # Collection / collection_name_s
-    config.add_facet_field 'collection_name_ssi', label: 'Collection', limit: 8, collapse: false
+    # Type / type_ssi
+    config.add_facet_field 'type_ssi', label: 'Type', limit: 4, collapse: true
 
-    # Type / types
-    config.add_facet_field 'type_ssi', label: 'Type', limit: 8, collapse: false
+    # Format / format_name_ssimv
+    config.add_facet_field 'format_name_ssimv', label: 'Format', limit: 4, collapse: true
 
-    # Format / format_name
-    config.add_facet_field 'format_name_ssimv', label: 'Format', limit: 8, collapse: false
+    # Created / date_created_ssortsi
+    config.add_facet_field 'date_ssi', label: 'Created', limit: 4, collapse: true
 
-    # Created / date_created_ss
-    config.add_facet_field 'date_created_sort_ssortsi', label: 'Created', limit: 8, collapse: false
+    # Subject / subject_ssim
+    config.add_facet_field 'subject_ssim', label: 'Subject', limit: 4, collapse: true
 
-    # Subject / subject_ss
-    config.add_facet_field 'subject_ssim', label: 'Subject', limit: 8, collapse: false
+    # Creator / creator_ssim
+    config.add_facet_field 'creator_ssim', label: 'Creator', limit: 4, collapse: true
 
-    # Creator / creator_ss
-    config.add_facet_field 'creator_ssim', label: 'Creator', limit: 8, collapse: false
+    # Publisher / publisher_ssi
+    config.add_facet_field 'publisher_ssi', label: 'Publisher', limit: 4, collapse: true
 
-    # Publisher / publisher_s
-    config.add_facet_field 'publisher_ssi', label: 'Publisher', limit: 8, collapse: false
+    # Contributor / contributor_ssim
+    config.add_facet_field 'contributor_ssim', label: 'Contributor', limit: 4, collapse: true
 
-    # Contributor / contributor_ss
-    config.add_facet_field 'contributor_ssim', label: 'Contributor', limit: 8, collapse: false
+    # Language / language_ssi
+    config.add_facet_field 'language_ssi', label: 'Language', limit: 4, collapse: true
 
-    # Language / language
-    config.add_facet_field 'language_ssi', label: 'Language', limit: 8, collapse: false
+    #SEARCH RESULTS FIELDS
+    # Description
+    config.add_index_field 'description_ts', :label => 'Description'
+    # Creator
+    config.add_index_field 'creator_ssim', :label => 'Creator'
+
+    # Created
+    config.add_index_field 'date_created_sort_ssortsi', :label => 'Created'
+
+    # Contributed By
+    config.add_index_field 'contributor_ssim', :label => 'Contributed By'
+
+    # Last Updated
+    config.add_index_field 'dmmodified_ssi', :label => 'Last Updated'
+
+    # Thumbnails
+    config.index.thumbnail_field = :object_ssi
+
+    #ITEM VIEW FIELDS
+    # Title
+    config.add_show_field 'title_ssi', label: 'Title', itemprop: 'title'
+    # Description
+    config.add_show_field 'description_ts', label: 'Description', itemprop: 'description'
+    # Date Created
+    config.add_show_field 'date_created_sort_ssortsi', label: 'Date Created', itemprop: 'date_created', link_to_facet: true
+    # Creator
+    config.add_show_field 'creator_ssim', label: 'Creator', itemprop: 'creator', link_to_facet: true
+
+    ## Physical Description
+    # Item Type
+    config.add_show_field 'type_ssi', label: 'Type', itemprop: 'type', link_to_facet: true
+    # Format
+    config.add_show_field 'format_ssim', label: 'Format', itemprop: 'format', link_to_facet: true
+
+    ## Topics
+    # Subjects
+    config.add_show_field 'subject_ssim', label: 'Subject', itemprop: 'subject', link_to_facet: true
+    # Language
+    config.add_show_field 'language_ssi', label: 'Language', itemprop: 'language', link_to_facet: true
+
+    ## Geographic Location
+    # Country
+    config.add_show_field 'country_ssi', label: 'Country', itemprop: 'country', link_to_facet: true
+
+    ## Collection Information
+    # Parent Collection
+    config.add_show_field 'collection_name_ssi', label: 'Parent Collection', itemprop: 'parent_collection_name', link_to_facet: true
+    # Contributing Organization
+    config.add_show_field 'contributing_organization_ssi', label: 'Contributing Organization', itemprop: 'contributing_organization', link_to_facet: true
+    # Contact Information
+    config.add_show_field 'contact_information_ssi', label: 'Contact Information', itemprop: 'contact_information'
+    # Fiscal Sponsor
+    config.add_show_field 'fiscal_sponsor_ssi', label: 'Fiscal Sponsor', itemprop: 'fiscal_sponsor'
+
+    ## Identifiers
+    # DLS Identifier
+    config.add_show_field 'local_identifier_ssi', label: 'DLS Identifier', itemprop: 'identifier'
+
+    ## Can I Use It?
+    # Copyright Statement...
+    config.add_show_field 'local_rights_tesi', label: 'Copyright Statement', itemprop: 'copyright'
+
+    # View Helpers
+  # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    config.add_results_collection_tool(:sort_widget)
+    config.add_results_collection_tool(:per_page_widget)
+    config.add_results_collection_tool(:view_type_group)
 
     config.add_facet_fields_to_solr_request!
+    config.add_field_configuration_to_solr_request!
 
     # Set which views by default only have the title displayed, e.g.,
     # config.view.gallery.title_only_by_default = true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,6 +39,9 @@ class CatalogController < ApplicationController
     config.add_sort_field 'creator_sort_ssortsi desc', :label => 'Creator (Z-A)'
 
     # FACETS
+    ## config.add_facet_field 'super_collection_name_ss', label: 'Special Projects',
+    ##                        limit: 4, collapse: true
+
     # Contributing Organization / contributing_organization_ssi
     config.add_facet_field 'contributing_organization_ssi', label: 'Contributing Organization',
                            limit: 4, collapse: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,7 @@ class CatalogController < ApplicationController
   configure_blacklight do |config|
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
+    config.raw_endpoint.enabled = true
 
     config.view.gallery.document_component = Blacklight::Gallery::DocumentComponent
     # config.view.gallery.classes = 'row-cols-2 row-cols-md-3'
@@ -31,20 +32,21 @@ class CatalogController < ApplicationController
     config.add_search_field 'all_fields', label: I18n.t('spotlight.search.fields.search.all_fields')
 
     config.add_sort_field 'relevance', sort: 'score desc', label: I18n.t('spotlight.search.fields.sort.relevance')
-    config.add_sort_field "date_created_sort_ssortsi desc, title_sort_ssortsi asc", :label => 'Year (Newest first)'
-    config.add_sort_field "date_created_sort_ssortsi asc, title_sort_ssortsi asc", :label => 'Year (Oldest first)'
-    config.add_sort_field 'title_sort_ssortsi asc', :label => 'Title (A-Z)'
-    config.add_sort_field 'title_sort_ssortsi desc', :label => 'Title (Z-A)'
-    config.add_sort_field 'creator_sort_ssortsi asc', :label => 'Creator (A-Z)'
-    config.add_sort_field 'creator_sort_ssortsi desc', :label => 'Creator (Z-A)'
+    config.add_sort_field 'date_created_sort_ssortsi desc, title_sort_ssortsi asc', label: 'Year (Newest first)'
+    config.add_sort_field 'date_created_sort_ssortsi asc, title_sort_ssortsi asc', label: 'Year (Oldest first)'
+    config.add_sort_field 'title_sort_ssortsi asc', label: 'Title (A-Z)'
+    config.add_sort_field 'title_sort_ssortsi desc', label: 'Title (Z-A)'
+    config.add_sort_field 'creator_sort_ssortsi asc', label: 'Creator (A-Z)'
+    config.add_sort_field 'creator_sort_ssortsi desc', label: 'Creator (Z-A)'
 
     # FACETS
+    # @TODO - Special Projects
     ## config.add_facet_field 'super_collection_name_ss', label: 'Special Projects',
     ##                        limit: 4, collapse: true
 
     # Contributing Organization / contributing_organization_ssi
     config.add_facet_field 'contributing_organization_ssi', label: 'Contributing Organization',
-                           limit: 4, collapse: true
+                                                            limit: 4, collapse: true
 
     # Collection / collection_name_ssi
     config.add_facet_field 'collection_name_ssi', label: 'Collection', limit: 4, collapse: true
@@ -73,31 +75,32 @@ class CatalogController < ApplicationController
     # Language / language_ssi
     config.add_facet_field 'language_ssi', label: 'Language', limit: 4, collapse: true
 
-    #SEARCH RESULTS FIELDS
+    # SEARCH RESULTS FIELDS
     # Description
-    config.add_index_field 'description_ts', :label => 'Description'
+    config.add_index_field 'description_ts', label: 'Description'
     # Creator
-    config.add_index_field 'creator_ssim', :label => 'Creator'
+    config.add_index_field 'creator_ssim', label: 'Creator'
 
     # Created
-    config.add_index_field 'date_created_sort_ssortsi', :label => 'Created'
+    config.add_index_field 'date_created_sort_ssortsi', label: 'Created'
 
     # Contributed By
-    config.add_index_field 'contributor_ssim', :label => 'Contributed By'
+    config.add_index_field 'contributor_ssim', label: 'Contributed By'
 
     # Last Updated
-    config.add_index_field 'dmmodified_ssi', :label => 'Last Updated'
+    config.add_index_field 'dmmodified_ssi', label: 'Last Updated'
 
     # Thumbnails
     config.index.thumbnail_field = :object_ssi
 
-    #ITEM VIEW FIELDS
+    # ITEM VIEW FIELDS
     # Title
     config.add_show_field 'title_ssi', label: 'Title', itemprop: 'title'
     # Description
     config.add_show_field 'description_ts', label: 'Description', itemprop: 'description'
     # Date Created
-    config.add_show_field 'date_created_sort_ssortsi', label: 'Date Created', itemprop: 'date_created', link_to_facet: true
+    config.add_show_field 'date_created_sort_ssortsi', label: 'Date Created', itemprop: 'date_created',
+                                                       link_to_facet: true
     # Creator
     config.add_show_field 'creator_ssim', label: 'Creator', itemprop: 'creator', link_to_facet: true
 
@@ -119,9 +122,11 @@ class CatalogController < ApplicationController
 
     ## Collection Information
     # Parent Collection
-    config.add_show_field 'collection_name_ssi', label: 'Parent Collection', itemprop: 'parent_collection_name', link_to_facet: true
+    config.add_show_field 'collection_name_ssi', label: 'Parent Collection', itemprop: 'parent_collection_name',
+                                                 link_to_facet: true
     # Contributing Organization
-    config.add_show_field 'contributing_organization_ssi', label: 'Contributing Organization', itemprop: 'contributing_organization', link_to_facet: true
+    config.add_show_field 'contributing_organization_ssi', label: 'Contributing Organization',
+                                                           itemprop: 'contributing_organization', link_to_facet: true
     # Contact Information
     config.add_show_field 'contact_information_ssi', label: 'Contact Information', itemprop: 'contact_information'
     # Fiscal Sponsor
@@ -136,7 +141,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'local_rights_tesi', label: 'Copyright Statement', itemprop: 'copyright'
 
     # View Helpers
-  # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,0 +1,13 @@
+<div class="jumbotron text-center p-5 mb-4 bg-light rounded-3">
+  <h1 class="jumbotron-heading"><%= t('blacklight.welcome') %></h1>
+  <h1 class="jumbotron-heading">UMedia</h1>
+  <p class="lead">Begin</p>
+</div>
+
+<script>
+  Blacklight.onLoad(function() {
+    $('#about .card-header').one('click', function() {
+      $($(this).data('target')).load($(this).find('a').attr('href'));
+    });
+  });
+</script>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,0 +1,18 @@
+<nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
+  <div class="<%= container_classes %>">
+    <%= link_to application_name, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
+      <%= render 'shared/user_util_links' %>
+    </div>
+  </div>
+</nav>
+
+<%= content_tag :div, class: 'navbar-search navbar navbar-light bg-light', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
+  <div class="<%= container_classes %>">
+    <%= render_search_bar  %>
+  </div>
+<% end %>

--- a/lib/tasks/umedia.rake
+++ b/lib/tasks/umedia.rake
@@ -83,15 +83,15 @@ namespace :umedia do
       puts res.body
     end
 
-    desc "Start solr server for testing."
-    task :test do
+    desc 'Start solr server for testing.'
+    task test: :environment do
       if Rails.env.test?
         shared_solr_opts = { managed: true, verbose: true, persist: false, download_dir: 'tmp' }
         shared_solr_opts[:version] = ENV['SOLR_VERSION'] if ENV['SOLR_VERSION']
 
         SolrWrapper.wrap(shared_solr_opts.merge(port: 8983, instance_dir: 'tmp/blacklight-core')) do |solr|
-          solr.with_collection(name: "blacklight-core", dir: Rails.root.join("solr", "conf").to_s) do
-            puts "Solr running at http://localhost:8983/solr/#/blacklight-core/, ^C to exit"
+          solr.with_collection(name: 'blacklight-core', dir: Rails.root.join('solr/conf').to_s) do
+            puts 'Solr running at http://localhost:8983/solr/#/blacklight-core/, ^C to exit'
             begin
               Rake::Task['umedia:index:seed'].invoke
               sleep

--- a/lib/tasks/umedia.rake
+++ b/lib/tasks/umedia.rake
@@ -11,6 +11,7 @@ RuboCop::RakeTask.new(:rubocop)
 desc 'Run test suite'
 task ci: :environment do
   success = true
+  system('bundle exec rake umedia:index:seed') || success = false
   system('RAILS_ENV=test bundle exec rails test:system test') || success = false
   system('bundle exec rake bundle:audit') || success = false
   exit!(1) unless success
@@ -18,6 +19,13 @@ end
 
 namespace :umedia do
   namespace :index do
+    desc 'Put all sample data into solr'
+    task seed: :environment do
+      docs = Dir['test/fixtures/files/solr_documents/*.json'].map { |f| JSON.parse File.read(f) }.flatten
+      Blacklight.default_index.connection.add docs
+      Blacklight.default_index.connection.commit
+    end
+
     desc 'Harvest'
     task harvest: :environment do
       # mpls          => MDL collection

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     'disable-gpu' # https://developers.google.com/web/updates/2017/04/headless-chrome
   ].each { |arg| options.add_argument(arg) }
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [options])
 end
 
 Capybara::Screenshot.register_driver(:selenium_chrome_headless) do |driver, path|

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -5,4 +5,9 @@ class CatalogControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
   end
+
+  test 'should get catalog#show/raw' do
+    get '/catalog/p16022coll282:4660/raw'
+    assert_response :success
+  end
 end

--- a/test/fixtures/files/solr_documents/moving_image.json
+++ b/test/fixtures/files/solr_documents/moving_image.json
@@ -1,0 +1,121 @@
+{
+  "id": "p16022coll262:173",
+  "object_ssi": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll262/id/173",
+  "setspec_ssi": "p16022coll262",
+  "collection_name_ssi": "ul_ias - IAS Programming",
+  "collection_name_tesi": "ul_ias - IAS Programming",
+  "collection_description_tesi": "A collection of videos highlighting programming evens sponsored by the University of Minnesota's Institute for Advanced Study.",
+  "title_tesi": "The Haverford Group of Black Integrationists: Michael Lackey, Feb. 2014",
+  "title_ssi": "The Haverford Group of Black Integrationists: Michael Lackey, Feb. 2014",
+  "title_sort_ssortsi": "The Haverford Group of Black Integrationists: Michael Lackey, Feb. 2014",
+  "title_search_te_ascii": [
+    "The Haverford Group of Black Integrationists: Michael Lackey, Feb. 2014"
+  ],
+  "contributor_tesim": [
+    "Lackey, Michael"
+  ],
+  "contributor_ssim": [
+    "Lackey, Michael"
+  ],
+  "creator_tesimv": [
+    "Institute for Advanced Study"
+  ],
+  "creator_ssim": [
+    "Institute for Advanced Study"
+  ],
+  "creator_sort_ssortsi": "instituteforadvancedstudy",
+  "description_tesi": "Black Separatists, Black Integrationists, and the 1960s Battle for Racial Justice. IAS Thursdays at Four presents Michael Lackey, Professor of English, U of M Morris. Given that Brown versus Board of Education's racial promise of equality did not materialize, many prominent blacks in the 1960s supported separatism. We know this story, because Amiri Baraka, Stokely Carmichael, Eldridge Cleaver, Harold Cruse, Addison Gayle, and many others have intelligently articulated it in memorable works of the late sixties and early seventies. But there were rumors about a group of black integrationists who wanted to publish a multi-authored counter-testament that would offer a substantive critique of black separatism and make the case for integration. These writers were referred to as the Haverford Group. But who were they? Why was their work not published? And what were their arguments? In an archive at Brown University, Michael Lackey found the manuscript that the Haverford Group intended to publish, and he has now edited and annotated it and written a history of the Group and their black integrationist manifesto. In this lecture, Lackey will share some of his thoughts about Haverford Group members such as Ralph Ellison, John Hope Franklin, St. Clair Drake, and Kenneth Clark and their approach to racial justice in the United States. In the late sixties and early seventies, black separatist movements were sweeping across the United States. This was the era of The Autobiography of Malcolm X, Stokely Carmichael's and Charles Hamilton's Black Power, and Eldridge Cleaver's Soul on Ice. In 1969 a group of distinguished African American intellectuals met at Haverford College in order to devise strategies to dissuade young blacks from adopting a separatist political agenda. The participants included some of the most prominent figures of the civil rights era--Ralph Ellison, John Hope Franklin, and J. Saunders Redding, to name only a notable few. Although these discussions were recorded, transcribed, and edited, they were never published because the funding for them was withdrawn. This volume at last makes the historic Haverford discussions available, rescuing for the modern reader some of the most eloquent voices in the intellectual history of black America. Michael Lackey has edited and annotated the transcript of this lively exchange, and Alfred E. Prettyman has supplied an afterword. While acknowledging the importance of the black power and separatist movements, Lackey's introduction also sheds light on the insights offered by critics of those movements. Despite the frequent characterization of the dissenting integrationists as Uncle Toms or establishment intellectuals, a misrepresentation that has marginalized them in the intervening decades, Lackey argues that they had their own compelling vision for black empowerment and sociopolitical integration.",
+  "description_ts": "Black Separatists, Black Integrationists, and the 1960s Battle for Racial Justice. IAS Thursdays at Four presents Michael Lackey, Professor of English, U of M Morris. Given that Brown versus Board of Education's racial promise of equality did not materialize, many prominent blacks in the 1960s supported separatism. We know this story, because Amiri Baraka, Stokely Carmichael, Eldridge Cleaver, Harold Cruse, Addison Gayle, and many others have intelligently articulated it in memorable works of the late sixties and early seventies. But there were rumors about a group of black integrationists who wanted to publish a multi-authored counter-testament that would offer a substantive critique of black separatism and make the case for integration. These writers were referred to as the Haverford Group. But who were they? Why was their work not published? And what were their arguments? In an archive at Brown University, Michael Lackey found the manuscript that the Haverford Group intended to publish, and he has now edited and annotated it and written a history of the Group and their black integrationist manifesto. In this lecture, Lackey will share some of his thoughts about Haverford Group members such as Ralph Ellison, John Hope Franklin, St. Clair Drake, and Kenneth Clark and their approach to racial justice in the United States. In the late sixties and early seventies, black separatist movements were sweeping across the United States. This was the era of The Autobiography of Malcolm X, Stokely Carmichael's and Charles Hamilton's Black Power, and Eldridge Cleaver's Soul on Ice. In 1969 a group of distinguished African American intellectuals met at Haverford College in order to devise strategies to dissuade young blacks from adopting a separatist political agenda. The participants included some of the most prominent figures of the civil rights era--Ralph Ellison, John Hope Franklin, and J. Saunders Redding, to name only a notable few. Although these discussions were recorded, transcribed, and edited, they were never published because the funding for them was withdrawn. This volume at last makes the historic Haverford discussions available, rescuing for the modern reader some of the most eloquent voices in the intellectual history of black America. Michael Lackey has edited and annotated the transcript of this lively exchange, and Alfred E. Prettyman has supplied an afterword. While acknowledging the importance of the black power and separatist movements, Lackey's introduction also sheds light on the insights offered by critics of those movements. Despite the frequent characterization of the dissenting integrationists as Uncle Toms or establishment intellectuals, a misrepresentation that has marginalized them in the intervening decades, Lackey argues that they had their own compelling vision for black empowerment and sociopolitical integration.",
+  "date_created_te_split": [
+    "2014-02-13"
+  ],
+  "date_created_sort_ssortsi": "2014",
+  "date_added_dr": "2018-02-05T00:00:00Z",
+  "date_modified_dr": "2019-01-11T00:00:00Z",
+  "date_added_sort_dttsi": "2018-02-05T00:00:00Z",
+  "dimensions_ssi": "0:39:50",
+  "type_ssi": "Moving Image",
+  "type_tesi": "Moving Image",
+  "subject_ssim": [
+    "1960s American Racial Justice Movement",
+    "J. Saunders Redding, Amiri Baraka, Ralph Ellison, Kenneth Clark, St. Clair Drake, John Hope Franklin",
+    "Black Integrationism and Separatism",
+    "Sociocultural and Essentialist Attitudes on Race"
+  ],
+  "subject_tesimv": [
+    "1960s American Racial Justice Movement",
+    "J. Saunders Redding, Amiri Baraka, Ralph Ellison, Kenneth Clark, St. Clair Drake, John Hope Franklin",
+    "Black Integrationism and Separatism",
+    "Sociocultural and Essentialist Attitudes on Race"
+  ],
+  "language_ssim": [
+    "English"
+  ],
+  "city_tesim": [
+    "Minneapolis"
+  ],
+  "state_tesim": [
+    "Minnesota"
+  ],
+  "country_tesim": [
+    "United States"
+  ],
+  "continent_tesim": [
+    "North America"
+  ],
+  "keyword_tesi": "Black Integrationism and Separatism; J. Saunders Redding, Amiri Baraka, Ralph Ellison, Kenneth Clark, St. Clair Drake, John Hope Franklin; Sociocultural and Essentialist Attitudes on Race; 1960s American Racial Justice Movement",
+  "keyword_ssim": [
+    "Black Integrationism and Separatism",
+    "J. Saunders Redding, Amiri Baraka, Ralph Ellison, Kenneth Clark, St. Clair Drake, John Hope Franklin",
+    "Sociocultural and Essentialist Attitudes on Race",
+    "1960s American Racial Justice Movement"
+  ],
+  "city_ssim": [
+    "Minneapolis"
+  ],
+  "state_ssi": "Minnesota",
+  "country_ssi": "United States",
+  "language_ssi": "English",
+  "contributing_organization_tesi": "University of Minnesota, Institute for Advanced Study.",
+  "contributing_organization_name_tesi": "University of Minnesota, Institute for Advanced Study.",
+  "contact_information_tesi": "University of Minnesota, Institute for Advanced Study. 290 Northrop, 84 Church Street SE, Minneapolis, MN 55455; https://ias.umn.edu/",
+  "local_identifier_te_split": [
+    "14-02-13 T@4 Lackey"
+  ],
+  "dls_identifier_te_split": [
+    "ias00787"
+  ],
+  "persistent_url_ssi": "http://purl.umn.edu/246888",
+  "local_rights_tesi": "Use of this item may be governed by US and international copyright laws. You may be able to use this item, but copyright and other considerations may apply. For possible additional information or guidance on your use, please contact the contributing organization.",
+  "contributing_organization_ssi": "University of Minnesota, Institute for Advanced Study.",
+  "contact_information_ssi": "University of Minnesota, Institute for Advanced Study. 290 Northrop, 84 Church Street SE, Minneapolis, MN 55455; https://ias.umn.edu/",
+  "local_identifier_ssi": "14-02-13 T@4 Lackey",
+  "types_ssim": [
+    "Moving Image"
+  ],
+  "format_ssim": [
+    "Educational events | http://vocab.getty.edu/aat/300069086"
+  ],
+  "format_name_ssimv": [
+    "Educational events"
+  ],
+  "date_ssi": "2014-02-13",
+  "format_tesi": "Educational events | http://vocab.getty.edu/aat/300069086",
+  "find_ssi": "462.url",
+  "dmcreated_ssi": "2018-02-05",
+  "dmmodified_ssi": "2019-01-11",
+  "restriction_code_ssi": "1",
+  "cdmfilesize_ssi": "34",
+  "cdmfilesizeformatted_ssi": "0.00 MB",
+  "cdmprintpdf_is": 0,
+  "cdmhasocr_is": 0,
+  "cdmisnewspaper_is": 0,
+  "record_type_ssi": "primary",
+  "page_count_isi": 0,
+  "kaltura_video_ssi": "0_yztvjixg",
+  "document_type_ssi": "item",
+  "first_viewer_type_ssi": "kaltura_video",
+  "viewer_type_ssi": "kaltura_video",
+  "attachment_ss": "462.url",
+  "featured_collection_order_is": 999
+}

--- a/test/fixtures/files/solr_documents/sound.json
+++ b/test/fixtures/files/solr_documents/sound.json
@@ -1,0 +1,133 @@
+{
+  "id": "p16022coll171:7",
+  "object_ssi": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll171/id/7",
+  "setspec_ssi": "p16022coll171",
+  "collection_name_ssi": "ul_uar - University of Minnesota Archives Audio Collection",
+  "collection_name_tesi": "ul_uar - University of Minnesota Archives Audio Collection",
+  "collection_description_tesi": "Historical audio recordings held by the University of Minnesota Archives.",
+  "super_collection_names_tesim": [
+    "Minnesota's Radio History"
+  ],
+  "super_collection_set_specs_ssim": [
+    "p16022coll434"
+  ],
+  "super_collection_descriptions_tesim": [
+    "This project makes available audio recordings of radio programs produced by the oldest operating radio station in Minnesota, KUOM."
+  ],
+  "title_tesi": "The University of Minnesota's Constitutional Independence, Budget, and Educational Opportunities with speaker C. Peter MacGrath",
+  "title_ssi": "The University of Minnesota's Constitutional Independence, Budget, and Educational Opportunities with speaker C. Peter MacGrath",
+  "title_sort_ssortsi": "The University of Minnesota's Constitutional Independence, Budget, and Educational Opportunities with speaker C. Peter MacGrath",
+  "title_search_te_ascii": [
+    "The University of Minnesota's Constitutional Independence, Budget, and Educational Opportunities with speaker C. Peter MacGrath"
+  ],
+  "contributor_tesim": [
+    "Naftalin, Arthur; Magrath, C. Peter; Marlow, Andrew (Producer); Mickler (Engineer)"
+  ],
+  "contributor_ssim": [
+    "Naftalin, Arthur",
+    " Magrath, C. Peter",
+    " Marlow, Andrew (Producer)",
+    " Mickler (Engineer)"
+  ],
+  "creator_tesimv": [
+    "University of Minnesota. University Media Resources"
+  ],
+  "creator_ssim": [
+    "University of Minnesota. University Media Resources"
+  ],
+  "creator_sort_ssortsi": "universityofminnesotauniversitymediaresources",
+  "description_tesi": "Minnesota Issues was a half-hour weekly television program produced by University Media Resources of the University of Minnesota that was broadcast on public television channel KTCA, St. Paul. The program was produced and hosted by former Minneapolis mayor and University public affairs professor Arthur Naftalin from 1976 to 1988.",
+  "description_ts": "Minnesota Issues was a half-hour weekly television program produced by University Media Resources of the University of Minnesota that was broadcast on public television channel KTCA, St. Paul. The program was produced and hosted by former Minneapolis mayor and University public affairs professor Arthur Naftalin from 1976 to 1988.",
+  "date_created_te_split": [
+    "1977-12-16"
+  ],
+  "date_created_sort_ssortsi": "1977",
+  "date_added_dr": "2017-11-28T00:00:00Z",
+  "date_modified_dr": "2018-11-26T00:00:00Z",
+  "date_added_sort_dttsi": "2017-11-28T00:00:00Z",
+  "dimensions_ssi": "0:29:15",
+  "type_ssi": "Sound",
+  "type_tesi": "Sound",
+  "subject_ssim": [
+    "Minnesota Issues",
+    "Broadcast"
+  ],
+  "subject_tesimv": [
+    "Minnesota Issues",
+    "Broadcast"
+  ],
+  "language_ssim": [
+    "English"
+  ],
+  "city_tesim": [
+    "St. Paul",
+    "Minneapolis"
+  ],
+  "state_tesim": [
+    "Minnesota"
+  ],
+  "country_tesim": [
+    "United States"
+  ],
+  "continent_tesim": [
+    "North America"
+  ],
+  "parent_collection_tesi": "University of Minnesota Radio and Television Broadcasting records (ua 01039); http://archives.lib.umn.edu/repositories/14/resources/5852",
+  "parent_collection_name_ssi": "University of Minnesota Radio and Television Broadcasting records (ua 01039)",
+  "keyword_tesi": "Broadcast; Minnesota Issues",
+  "keyword_ssim": [
+    "Broadcast",
+    "Minnesota Issues"
+  ],
+  "city_ssim": [
+    "St. Paul",
+    "Minneapolis"
+  ],
+  "state_ssi": "Minnesota",
+  "country_ssi": "United States",
+  "language_ssi": "English",
+  "contributing_organization_tesi": "University of Minnesota Libraries, University Archives.",
+  "contributing_organization_name_tesi": "University of Minnesota Libraries, University Archives.",
+  "contact_information_tesi": "University of Minnesota Libraries, University Archives. 218 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/uarchives",
+  "fiscal_sponsor_tesi": "This project has been financed in part with funds provided by the State of Minnesota from the Arts and Cultural Heritage Fund through the Minnesota Historical Society.",
+  "local_identifier_te_split": [
+    "722-011"
+  ],
+  "dls_identifier_te_split": [
+    "uarc1125_tray113_722-011"
+  ],
+  "persistent_url_ssi": "http://purl.umn.edu/251423",
+  "local_rights_tesi": "Use of this item may be governed by US and international copyright laws. You may be able to use this item, but copyright and other considerations may apply. For possible additional information or guidance on your use, please contact the contributing organization.",
+  "contributing_organization_ssi": "University of Minnesota Libraries, University Archives.",
+  "contact_information_ssi": "University of Minnesota Libraries, University Archives. 218 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/uarchives",
+  "local_identifier_ssi": "722-011",
+  "fiscal_sponsor_ssi": "This project has been financed in part with funds provided by the State of Minnesota from the Arts and Cultural Heritage Fund through the Minnesota Historical Society.",
+  "types_ssim": [
+    "Sound"
+  ],
+  "format_ssim": [
+    "Radio programs | http://vocab.getty.edu/aat/300387763"
+  ],
+  "format_name_ssimv": [
+    "Radio programs"
+  ],
+  "date_ssi": "1977-12-16",
+  "format_tesi": "Radio programs | http://vocab.getty.edu/aat/300387763",
+  "find_ssi": "19.url",
+  "dmcreated_ssi": "2017-11-28",
+  "dmmodified_ssi": "2018-11-26",
+  "restriction_code_ssi": "1",
+  "cdmfilesize_ssi": "34",
+  "cdmfilesizeformatted_ssi": "0.00 MB",
+  "cdmprintpdf_is": 0,
+  "cdmhasocr_is": 0,
+  "cdmisnewspaper_is": 0,
+  "record_type_ssi": "primary",
+  "page_count_isi": 0,
+  "kaltura_audio_ssi": "0_f3dlm3pg",
+  "document_type_ssi": "item",
+  "first_viewer_type_ssi": "kaltura_audio",
+  "viewer_type_ssi": "kaltura_audio",
+  "attachment_ss": "19.url",
+  "featured_collection_order_is": 999
+}

--- a/test/fixtures/files/solr_documents/still_image.json
+++ b/test/fixtures/files/solr_documents/still_image.json
@@ -1,0 +1,107 @@
+{
+  "id": "p16022coll208:11",
+  "object_ssi": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll208/id/11",
+  "setspec_ssi": "p16022coll208",
+  "collection_name_ssi": "ul_mss - World War Poster Collection",
+  "collection_name_tesi": "ul_mss - World War Poster Collection",
+  "collection_description_tesi": "Posters are from World Wars I and II and the German election of 1932. War posters are from U.S., Britain, Canada, France, Germany, Italy, Latin America, and Scandinavia. Subjects include recruiting, war bond sales, food conservation, civil defense and many other topics. Includes war posters from the collections of the Hennepin County Library. [Finding Aid available at: http://archives.lib.umn.edu/repositories/16/resources/2506]",
+  "title_tesi": "Go places! : with the : U.S. Army!",
+  "title_ssi": "Go places! : with the : U.S. Army!",
+  "title_sort_ssortsi": "Go places! : with the : U.S. Army!",
+  "title_search_te_ascii": [
+    "Go places! : with the : U.S. Army!"
+  ],
+  "contributor_tesim": [
+    "United States. Army"
+  ],
+  "contributor_ssim": [
+    "United States. Army"
+  ],
+  "description_tesi": "Six photographs of Army activities. Image of ship in center",
+  "description_ts": "Six photographs of Army activities. Image of ship in center",
+  "date_created_te_split": [
+    "1939 - 1945"
+  ],
+  "date_created_sort_ssortsi": "1939 ",
+  "date_added_dr": "2017-12-18T00:00:00Z",
+  "date_modified_dr": "2019-11-14T00:00:00Z",
+  "date_added_sort_dttsi": "2017-12-18T00:00:00Z",
+  "historical_era_ssim": [
+    "World War, 1939-1945"
+  ],
+  "dimensions_ssi": "97 x 64 centimeters",
+  "type_ssi": "Still Image",
+  "type_tesi": "Still Image",
+  "subject_ssim": [
+    "World War, 1939 1945. United States. Posters",
+    "Recruiting and Enlistment",
+    "Military Recruiting",
+    "United States. Army"
+  ],
+  "subject_tesimv": [
+    "World War, 1939 1945. United States. Posters",
+    "Recruiting and Enlistment",
+    "Military Recruiting",
+    "United States. Army"
+  ],
+  "language_ssim": [
+    "English"
+  ],
+  "country_tesim": [
+    "United States"
+  ],
+  "continent_tesim": [
+    "North America"
+  ],
+  "parent_collection_tesi": "World War Poster collection (Mss036); http://archives.lib.umn.edu/repositories/16/resources/2506",
+  "parent_collection_name_ssi": "World War Poster collection (Mss036)",
+  "keyword_tesi": "Military Recruiting; Recruiting and Enlistment; United States. Army; World War, 1939 1945. United States. Posters",
+  "keyword_ssim": [
+    "Military Recruiting",
+    "Recruiting and Enlistment",
+    "United States. Army",
+    "World War, 1939 1945. United States. Posters"
+  ],
+  "country_ssi": "United States",
+  "language_ssi": "English",
+  "contributing_organization_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contributing_organization_name_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contact_information_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives. 213 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/mss",
+  "fiscal_sponsor_tesi": "This resource was created with support from the Institute of Museum and Library Services.",
+  "dls_identifier_te_split": [
+    "msp02635"
+  ],
+  "persistent_url_ssi": "http://purl.umn.edu/76943",
+  "local_rights_tesi": "Use of this item may be governed by US and international copyright laws. You may be able to use this item, but copyright and other considerations may apply. For possible additional information or guidance on your use, please contact the contributing organization.",
+  "contributing_organization_ssi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contact_information_ssi": "University of Minnesota Libraries, Upper Midwest Literary Archives. 213 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/mss",
+  "fiscal_sponsor_ssi": "This resource was created with support from the Institute of Museum and Library Services.",
+  "notes_tesi": "P-20-RPB-7-10-39-12,500.",
+  "types_ssim": [
+    "Still Image"
+  ],
+  "format_ssim": [
+    "Posters | http://vocab.getty.edu/aat/300027221"
+  ],
+  "format_name_ssimv": [
+    "Posters"
+  ],
+  "date_ssi": "1939 - 1945",
+  "format_tesi": "Posters | http://vocab.getty.edu/aat/300027221",
+  "find_ssi": "2077.jp2",
+  "dmcreated_ssi": "2017-12-18",
+  "dmmodified_ssi": "2019-11-14",
+  "restriction_code_ssi": "1",
+  "cdmfilesize_ssi": "8841310",
+  "cdmfilesizeformatted_ssi": "8.43 MB",
+  "cdmprintpdf_is": 0,
+  "cdmhasocr_is": 0,
+  "cdmisnewspaper_is": 0,
+  "record_type_ssi": "primary",
+  "page_count_isi": 0,
+  "document_type_ssi": "item",
+  "first_viewer_type_ssi": "image",
+  "viewer_type_ssi": "image",
+  "attachment_ss": "2077.jp2",
+  "featured_collection_order_is": 999
+}

--- a/test/fixtures/files/solr_documents/still_image_publisher.json
+++ b/test/fixtures/files/solr_documents/still_image_publisher.json
@@ -1,0 +1,107 @@
+{
+  "id": "p16022coll208:200",
+  "object_ssi": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll208/id/200",
+  "setspec_ssi": "p16022coll208",
+  "collection_name_ssi": "ul_mss - World War Poster Collection",
+  "collection_name_tesi": "ul_mss - World War Poster Collection",
+  "collection_description_tesi": "Posters are from World Wars I and II and the German election of 1932. War posters are from U.S., Britain, Canada, France, Germany, Italy, Latin America, and Scandinavia. Subjects include recruiting, war bond sales, food conservation, civil defense and many other topics. Includes war posters from the collections of the Hennepin County Library. [Finding Aid available at: http://archives.lib.umn.edu/repositories/16/resources/2506]",
+  "title_tesi": "For service : 500 hours ... : in civilian defense",
+  "title_ssi": "For service : 500 hours ... : in civilian defense",
+  "title_sort_ssortsi": "For service : 500 hours ... : in civilian defense",
+  "title_search_te_ascii": [
+    "For service : 500 hours ... : in civilian defense"
+  ],
+  "contributor_tesim": [
+    "United States. Office of Civilian Defense"
+  ],
+  "contributor_ssim": [
+    "United States. Office of Civilian Defense"
+  ],
+  "description_tesi": "White text on black, civil defense badges with number of hours listed beneath each",
+  "description_ts": "White text on black, civil defense badges with number of hours listed beneath each",
+  "date_created_te_split": [
+    "1943"
+  ],
+  "date_created_sort_ssortsi": "1943",
+  "date_added_dr": "2017-12-18T00:00:00Z",
+  "date_modified_dr": "2019-11-14T00:00:00Z",
+  "date_added_sort_dttsi": "2017-12-18T00:00:00Z",
+  "historical_era_ssim": [
+    "World War, 1939-1945"
+  ],
+  "dimensions_ssi": "56 x 36 centimeters",
+  "type_ssi": "Still Image",
+  "type_tesi": "Still Image",
+  "subject_ssim": [
+    "World War, 1939 1945. United States. Posters",
+    "Recruiting and Enlistment",
+    "Civil Defense",
+    "Civil Defense"
+  ],
+  "subject_tesimv": [
+    "World War, 1939 1945. United States. Posters",
+    "Recruiting and Enlistment",
+    "Civil Defense",
+    "Civil Defense"
+  ],
+  "language_ssim": [
+    "English"
+  ],
+  "country_tesim": [
+    "United States"
+  ],
+  "continent_tesim": [
+    "North America"
+  ],
+  "parent_collection_tesi": "World War Poster collection (Mss036); http://archives.lib.umn.edu/repositories/16/resources/2506",
+  "parent_collection_name_ssi": "World War Poster collection (Mss036)",
+  "keyword_tesi": "Civil Defense; Recruiting and Enlistment; World War, 1939 1945. United States. Posters",
+  "keyword_ssim": [
+    "Civil Defense",
+    "Recruiting and Enlistment",
+    "World War, 1939 1945. United States. Posters"
+  ],
+  "country_ssi": "United States",
+  "language_ssi": "English",
+  "contributing_organization_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contributing_organization_name_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contact_information_tesi": "University of Minnesota Libraries, Upper Midwest Literary Archives. 213 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/mss",
+  "fiscal_sponsor_tesi": "This resource was created with support from the Institute of Museum and Library Services.",
+  "dls_identifier_te_split": [
+    "msp02337"
+  ],
+  "persistent_url_ssi": "http://purl.umn.edu/76648",
+  "local_rights_tesi": "Use of this item may be governed by US and international copyright laws. You may be able to use this item, but copyright and other considerations may apply. For possible additional information or guidance on your use, please contact the contributing organization.",
+  "contributing_organization_ssi": "University of Minnesota Libraries, Upper Midwest Literary Archives.",
+  "contact_information_ssi": "University of Minnesota Libraries, Upper Midwest Literary Archives. 213 Elmer L. Andersen Library, 222 - 21st Avenue South, Minneapolis, MN 55455; https://www.lib.umn.edu/mss",
+  "fiscal_sponsor_ssi": "This resource was created with support from the Institute of Museum and Library Services.",
+  "publisher_ssi": "U. S. Government Printing Office",
+  "notes_tesi": "OCD publication 7021\"/\"U. S. Government Printing Office : 1943--O-537768",
+  "types_ssim": [
+    "Still Image"
+  ],
+  "format_ssim": [
+    "Posters | http://vocab.getty.edu/aat/300027221"
+  ],
+  "format_name_ssimv": [
+    "Posters"
+  ],
+  "date_ssi": "1943",
+  "format_tesi": "Posters | http://vocab.getty.edu/aat/300027221",
+  "find_ssi": "815.jp2",
+  "dmcreated_ssi": "2017-12-18",
+  "dmmodified_ssi": "2019-11-14",
+  "restriction_code_ssi": "1",
+  "cdmfilesize_ssi": "2914457",
+  "cdmfilesizeformatted_ssi": "2.78 MB",
+  "cdmprintpdf_is": 0,
+  "cdmhasocr_is": 0,
+  "cdmisnewspaper_is": 0,
+  "record_type_ssi": "primary",
+  "page_count_isi": 0,
+  "document_type_ssi": "item",
+  "first_viewer_type_ssi": "image",
+  "viewer_type_ssi": "image",
+  "attachment_ss": "815.jp2",
+  "featured_collection_order_is": 999
+}

--- a/test/fixtures/files/solr_documents/text.json
+++ b/test/fixtures/files/solr_documents/text.json
@@ -1,0 +1,100 @@
+{
+  "id": "p16022coll282:4660",
+  "object_ssi": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll282/id/4660",
+  "setspec_ssi": "p16022coll282",
+  "collection_name_ssi": "ul_wan - Medical Receipt Books",
+  "collection_name_tesi": "ul_wan - Medical Receipt Books",
+  "collection_description_tesi": "A growing collection of domestic receipt books dating from the 17th through the 19th century. Often written by the mother of the house, they were used to care for family and sometimes livestock. Some of the receipts are written by physicians for the pharmacist to fill, but most consist of components that were readily available in local fields or the apothecary’s shop.",
+  "title_tesi": "Physical receipts",
+  "title_ssi": "Physical receipts",
+  "title_sort_ssortsi": "Physical receipts",
+  "title_search_te_ascii": [
+    "Physical receipts"
+  ],
+  "creator_tesimv": [
+    "Dixon, Elizabeth"
+  ],
+  "creator_ssim": [
+    "Dixon, Elizabeth"
+  ],
+  "creator_sort_ssortsi": "dixonelizabeth",
+  "description_tesi": "Calligraphic medicinal manuscript with 161 recipes of which 151 are in a single calligraphic hand and eight are in another; two recipes are tipped in. Handwritten. Includes index.",
+  "description_ts": "Calligraphic medicinal manuscript with 161 recipes of which 151 are in a single calligraphic hand and eight are in another; two recipes are tipped in. Handwritten. Includes index.",
+  "date_created_te_split": [
+    "1772"
+  ],
+  "date_created_sort_ssortsi": "1772",
+  "date_added_dr": "2020-06-29T00:00:00Z",
+  "date_modified_dr": "2020-06-29T00:00:00Z",
+  "date_added_sort_dttsi": "2020-06-29T00:00:00Z",
+  "dimensions_ssi": "156 pages, 22 unnumbered pages , 25 cm",
+  "type_ssi": "Text",
+  "type_tesi": "Text",
+  "subject_ssim": [
+    "Medicine Formulae, Receipts, Prescriptions",
+    "Medicine, Popular",
+    "Formularies",
+    "Medicine Popular Works"
+  ],
+  "subject_tesimv": [
+    "Medicine Formulae, Receipts, Prescriptions",
+    "Medicine, Popular",
+    "Formularies",
+    "Medicine Popular Works"
+  ],
+  "language_ssim": [
+    "English"
+  ],
+  "keyword_tesi": "Formularies; Medicine Popular Works; Medicine, Popular; Medicine Formulae, Receipts, Prescriptions",
+  "keyword_ssim": [
+    "Formularies",
+    "Medicine Popular Works",
+    "Medicine, Popular",
+    "Medicine Formulae, Receipts, Prescriptions"
+  ],
+  "language_ssi": "English",
+  "contributing_organization_tesi": "University of Minnesota Libraries, Wangensteen Historical Library of Biology and Medicine.",
+  "contributing_organization_name_tesi": "University of Minnesota Libraries, Wangensteen Historical Library of Biology and Medicine.",
+  "contact_information_tesi": "University of Minnesota Libraries, Wangensteen Historical Library of Biology and Medicine. Diehl Hall, 505 Essex Street SE, Minneapolis, MN 55455 ; https://hsl.lib.umn.edu/wangensteen",
+  "local_identifier_te_split": [
+    "WZ260 D621p 1772"
+  ],
+  "barcode_ssi": "UMN_BARCODE:31951D026929970",
+  "system_identifier_te_split": [
+    "UMN_ALMA:9952394810001701"
+  ],
+  "dls_identifier_te_split": [
+    "31951D026929970"
+  ],
+  "local_rights_tesi": "Use of this item may be governed by US and international copyright laws. You may be able to use this item, but copyright and other considerations may apply. For possible additional information or guidance on your use, please contact the contributing organization.",
+  "contributing_organization_ssi": "University of Minnesota Libraries, Wangensteen Historical Library of Biology and Medicine.",
+  "contact_information_ssi": "University of Minnesota Libraries, Wangensteen Historical Library of Biology and Medicine. Diehl Hall, 505 Essex Street SE, Minneapolis, MN 55455 ; https://hsl.lib.umn.edu/wangensteen",
+  "local_identifier_ssi": "WZ260 D621p 1772",
+  "types_ssim": [
+    "Text"
+  ],
+  "format_ssim": [
+    "Cookbooks | http://vocab.getty.edu/aat/300026109"
+  ],
+  "format_name_ssimv": [
+    "Cookbooks"
+  ],
+  "date_ssi": "1772",
+  "format_tesi": "Cookbooks | http://vocab.getty.edu/aat/300026109",
+  "find_ssi": "4661.cpd",
+  "dmcreated_ssi": "2020-06-29",
+  "dmmodified_ssi": "2020-06-29",
+  "restriction_code_ssi": "1",
+  "cdmfilesize_ssi": "22911",
+  "cdmfilesizeformatted_ssi": "0.02 MB",
+  "cdmprintpdf_is": 1,
+  "cdmhasocr_is": 0,
+  "cdmisnewspaper_is": 0,
+  "record_type_ssi": "primary",
+  "page_count_isi": 188,
+  "document_type_ssi": "item",
+  "first_viewer_type_ssi": "image",
+  "viewer_type_ssi": "COMPOUND_PARENT_NO_VIEWER",
+  "attachment_ss": "4661.cpd",
+  "featured_collection_order_is": 999
+}

--- a/test/system/homepage_test.rb
+++ b/test/system/homepage_test.rb
@@ -3,12 +3,38 @@
 require 'application_system_test_case'
 
 class HomepageTest < ApplicationSystemTestCase
-  test 'homepage dom' do
-    visit root_url
+  def setup; end
+
+  test 'Homepage Dom' do
+    visit '/'
     assert page.has_selector?('nav.navbar')
     assert page.has_selector?('main#main-container')
     assert page.has_selector?('div.jumbotron')
-    assert page.has_selector?('div#getting-started')
-    assert page.has_selector?('div#about')
+  end
+
+  test 'Homepage Facets' do
+    visit '/'
+    within('#facets') do
+      assert page.has_content?('Contributing Organization')
+      assert page.has_content?('Collection')
+      assert page.has_content?('Type')
+      assert page.has_content?('Format')
+      assert page.has_content?('Created')
+      assert page.has_content?('Subject')
+      assert page.has_content?('Creator')
+      assert page.has_content?('Publisher')
+      assert page.has_content?('Contributor')
+      assert page.has_content?('Language')
+    end
+  end
+
+  test 'Search Form' do
+    visit '/'
+    within('div.navbar-search') do
+      fill_in('q', with: 'water')
+      click_button 'Search'
+    end
+
+    assert page.has_content?('Search Results')
   end
 end

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class HomepageTest < ApplicationSystemTestCase
+  test 'Search Results -  Dom' do
+    visit '/?q=cookbooks'
+    assert page.has_selector?('nav.navbar')
+    assert page.has_selector?('main#main-container')
+    assert page.has_selector?('form.search-query-form')
+    assert page.has_selector?('div.constraints-container')
+    assert page.has_selector?('div#facets')
+    assert page.has_selector?('section#content')
+    assert page.has_selector?('div#documents')
+  end
+
+  test 'Search Result - Result Dom' do
+    visit '/?search_field=all_fields&q=p16022coll282%3A4660'
+    within('article') do
+      assert page.has_selector?('header.documentHeader')
+      assert page.has_selector?('h3.index_title')
+      assert page.has_selector?('span.document-counter')
+      assert page.has_link?('Physical receipts')
+      assert page.has_selector?('div.document-thumbnail')
+      assert page.has_selector?('div.document-thumbnail')
+      assert page.has_selector?('dl.document-metadata')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds basic field configuration to the CatalogController for: facets, search results, and show pages. It also adds the catalog#show/raw action to view the Solr JSON output for documents. PR includes system tests to cover the `catalog_controller.rb` file configuration changes. It also adds a controller test for the `/raw` action.

Fixes #3 

PR includes work from @tantz001 and @ewlarson 

<img width="1203" alt="Screen Shot 2022-03-27 at 1 17 05 PM" src="https://user-images.githubusercontent.com/69827/160295039-23d78272-30f5-45f3-8c08-1838bd8642cf.png">

