### PR TITLE
Install alias /item/:id route for catalog#show

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
   end
+
+  # For compatibility catalog show pages aliased as /item/:id
+  get '/item/:id', to: 'catalog#show'
+
   devise_for :users
   concern :exportable, Blacklight::Routes::Exportable.new
 

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -10,4 +10,9 @@ class CatalogControllerTest < ActionDispatch::IntegrationTest
     get '/catalog/p16022coll282:4660/raw'
     assert_response :success
   end
+
+  test 'should map item/:id to catalog#show' do
+    get '/item/p16022coll282:4660'
+    assert_response :success
+  end
 end


### PR DESCRIPTION
UMedia will want `/item/p16022coll282:9999` for compatibility, which can at least double up `/catalog/p16022coll282:9999` per `CatalogController`'s default behavior.