### PR TITLE
intial sitemap_generator config

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -2,12 +2,25 @@
 
 require 'sitemap_generator'
 
-# TODO: Update the default host to match your deployment environment
-SitemapGenerator::Sitemap.default_host = 'http://localhost/'
+# set the correct hostname
+SitemapGenerator::Sitemap.default_host = 'https://umedia.lib.umn.edu'
 
+# setting correct solr instance in config/blacklight.yaml
+solrinst = RSolr.connect url: Blacklight.connection_config[:url]
+
+# grab primary items and the dates they were last modified
+response = solrinst.get('select', params: { q: 'record_type_ssi:primary', fl: 'id,dmmodified_ssi', rows: 9_999_999 })
+
+# including the routes already defined in Rails and Spotlight
 SitemapGenerator::Interpreter.send :include, Rails.application.routes.url_helpers
 SitemapGenerator::Interpreter.send :include, Spotlight::Engine.routes.url_helpers
 
+# create the sitemap itself
 SitemapGenerator::Sitemap.create do
+  response['response']['docs'].each do |doc|
+    puts doc['id']
+    puts doc['dmmodified_ssi']
+    add "/item/#{doc['id']}", changefreq: 'weekly', lastmod: doc['dmmodified_ssi']
+  end
   Spotlight::Sitemap.add_all_exhibits(self)
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -18,8 +18,6 @@ SitemapGenerator::Interpreter.send :include, Spotlight::Engine.routes.url_helper
 # create the sitemap itself
 SitemapGenerator::Sitemap.create do
   response['response']['docs'].each do |doc|
-    puts doc['id']
-    puts doc['dmmodified_ssi']
     add "/item/#{doc['id']}", changefreq: 'weekly', lastmod: doc['dmmodified_ssi']
   end
   Spotlight::Sitemap.add_all_exhibits(self)


### PR DESCRIPTION
- includes only 'primary' items
- grabs item 'lastmod' values based on the last recorded modification date in Solr
- includes Rails default routes and Spotlight exhibits as needed
